### PR TITLE
Expo migration feasibility plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,24 @@ prep-all: \
 prep-%: $(CLIENT)/dist/media/%.bundle.obd $(CLIENT)/src/*
 	mkdir -p dist/
 	mv $(CLIENT)/dist/media/$*.bundle.obd $(CLIENT)/dist/media/bundle.obd
-	cp $(CLIENT)/src/environments/environment.prod.$*.ts $(CLIENT)/src/environments/environment.prod.ts
-	sed \
-		-e 's/%%VERSION%%/$(APPVERSION)/g' \
-		$(CLIENT)/config/config.$*.xml > \
-		$(CLIENT)/config.xml
+	@if [ -n "$(VARIANT_JSON)" ]; then \
+		echo "Configuring from VARIANT_JSON=$(VARIANT_JSON)"; \
+		node $(CURDIR)/scripts/configure-inner-repo.js --variant "$(VARIANT_JSON)" --version "$(APPVERSION)"; \
+	elif [ -f "$(CURDIR)/variants/$*.json" ]; then \
+		echo "Configuring from variants/$*.json"; \
+		node $(CURDIR)/scripts/configure-inner-repo.js --variant "$(CURDIR)/variants/$*.json" --version "$(APPVERSION)"; \
+	elif [ -f "$(CLIENT)/src/environments/environment.prod.$*.ts" ] && [ -f "$(CLIENT)/config/config.$*.xml" ]; then \
+		echo "Configuring from legacy client/src/environments/environment.prod.$*.ts + client/config/config.$*.xml"; \
+		cp $(CLIENT)/src/environments/environment.prod.$*.ts $(CLIENT)/src/environments/environment.prod.ts; \
+		sed \
+			-e 's/%%VERSION%%/$(APPVERSION)/g' \
+			$(CLIENT)/config/config.$*.xml > \
+			$(CLIENT)/config.xml; \
+	else \
+		echo "ERROR: No variant config found for '$*'."; \
+		echo "Set VARIANT_JSON=/path/to/$*.json or add variants/$*.json (or restore legacy client/config + env files)."; \
+		exit 1; \
+	fi
 
 # Later, we should make this target ONLY run if something has changed in CLIENT
 cycle-cordova-platform:

--- a/injectables/config.xml
+++ b/injectables/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.oralbibleapp.%translation-key%" version="%version%" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="%widget-id%" version="%version%" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>%app-name%</name>
     <description>%app-description%</description>
     <author email="chris@meekhouse.org">OpenOralBible</author>

--- a/injectables/environment.prod.ts
+++ b/injectables/environment.prod.ts
@@ -2,8 +2,8 @@ export const environment = {
     appName: "%app-name%",
     production: true,
     backend: {
-      releaseEndpoint: "https://content.oralbible.app/api/v1/%translation-key%/release",
-      audioEndpoint: "https://content.oralbible.app/api/v1/%translation-key%/audio",
+      releaseEndpoint: "%release-endpoint%",
+      audioEndpoint: "%audio-endpoint%",
     },
     features: {
       dynamicContent: true,

--- a/scripts/configure-inner-repo.js
+++ b/scripts/configure-inner-repo.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Configure this repo as an “inner repo” for multi-variant builds.
+ *
+ * The outer repo calls this script with a variant JSON file and it generates:
+ * - client/config.xml
+ * - client/src/environments/environment.prod.ts
+ * - client/src/environments/environment.ts (optional, but keeps local dev consistent)
+ *
+ * Usage:
+ *   node scripts/configure-inner-repo.js --variant /path/to/variant.json --version 1.2.3
+ *
+ * Variant JSON (example):
+ * {
+ *   "variant": "yetfa",
+ *   "translationKey": "yetfa",
+ *   "appName": "Awa Ma",
+ *   "appDescription": "OpenOralBible",
+ *   "widgetId": "com.oralbibleapp.yetfa",
+ *   "backend": {
+ *     "baseUrl": "https://content.oralbible.app",
+ *     "releaseEndpoint": "https://content.oralbible.app/api/v1/yetfa/release",
+ *     "audioEndpoint": "https://content.oralbible.app/api/v1/yetfa/audio"
+ *   }
+ * }
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function die(msg) {
+  process.stderr.write(String(msg).trimEnd() + '\n');
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--variant') args.variant = argv[++i];
+    else if (a === '--version') args.version = argv[++i];
+    else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--help' || a === '-h') args.help = true;
+    else args._.push(a);
+  }
+  return args;
+}
+
+function readJson(filePath) {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (e) {
+    die(`Failed to read JSON at ${filePath}: ${e && e.message ? e.message : e}`);
+  }
+}
+
+function ensureDirForFile(filePath) {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function renderTemplate(template, vars) {
+  return template.replace(/%([a-zA-Z0-9_-]+)%/g, (_, key) => {
+    const k = String(key);
+    if (!(k in vars)) {
+      die(`Template placeholder %${k}% not provided`);
+    }
+    return String(vars[k]);
+  });
+}
+
+function writeFile(filePath, contents, dryRun) {
+  if (dryRun) {
+    process.stdout.write(`[dry-run] would write ${filePath} (${Buffer.byteLength(contents, 'utf8')} bytes)\n`);
+    return;
+  }
+  ensureDirForFile(filePath);
+  fs.writeFileSync(filePath, contents, 'utf8');
+}
+
+function buildEndpoints(variant) {
+  const translationKey = variant.translationKey;
+  const backend = variant.backend || {};
+
+  if (backend.releaseEndpoint && backend.audioEndpoint) {
+    return {
+      releaseEndpoint: backend.releaseEndpoint,
+      audioEndpoint: backend.audioEndpoint,
+    };
+  }
+
+  const baseUrl = backend.baseUrl || 'https://content.oralbible.app';
+  if (!translationKey) die('variant.translationKey is required (used to build default endpoints)');
+
+  return {
+    releaseEndpoint: `${baseUrl.replace(/\/$/, '')}/api/v1/${translationKey}/release`,
+    audioEndpoint: `${baseUrl.replace(/\/$/, '')}/api/v1/${translationKey}/audio`,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  if (args.help) {
+    process.stdout.write('Usage: node scripts/configure-inner-repo.js --variant <variant.json> [--version <x.y.z>] [--dry-run]\n');
+    process.exit(0);
+  }
+  if (!args.variant) die('Missing required arg: --variant <path-to-variant.json>');
+
+  const repoRoot = path.resolve(__dirname, '..');
+  const variantPath = path.resolve(process.cwd(), args.variant);
+  const variant = readJson(variantPath);
+
+  const appName = variant.appName;
+  const translationKey = variant.translationKey || variant.variant;
+  const appDescription = variant.appDescription || '';
+
+  if (!appName) die('variant.appName is required');
+  if (!translationKey) die('variant.translationKey (or variant.variant) is required');
+
+  const version = args.version || variant.version || process.env.APP_VERSION || '0.0.0';
+  const widgetId = variant.widgetId || `com.oralbibleapp.${translationKey}`;
+
+  const endpoints = buildEndpoints({ ...variant, translationKey });
+
+  const templateVars = {
+    'app-name': appName,
+    'app-description': appDescription,
+    'translation-key': translationKey,
+    'version': version,
+    'widget-id': widgetId,
+    'release-endpoint': endpoints.releaseEndpoint,
+    'audio-endpoint': endpoints.audioEndpoint,
+  };
+
+  const configXmlTemplatePath = path.join(repoRoot, 'injectables', 'config.xml');
+  const envProdTemplatePath = path.join(repoRoot, 'injectables', 'environment.prod.ts');
+
+  const configXmlTemplate = fs.readFileSync(configXmlTemplatePath, 'utf8');
+  const envProdTemplate = fs.readFileSync(envProdTemplatePath, 'utf8');
+
+  const renderedConfigXml = renderTemplate(configXmlTemplate, templateVars);
+  const renderedEnvProd = renderTemplate(envProdTemplate, templateVars);
+
+  // Keep dev env matching prod endpoints unless the outer repo chooses otherwise.
+  const renderedEnvDev = renderedEnvProd.replace('production: true', 'production: false');
+
+  writeFile(path.join(repoRoot, 'client', 'config.xml'), renderedConfigXml, args.dryRun);
+  writeFile(path.join(repoRoot, 'client', 'src', 'environments', 'environment.prod.ts'), renderedEnvProd, args.dryRun);
+  writeFile(path.join(repoRoot, 'client', 'src', 'environments', 'environment.ts'), renderedEnvDev, args.dryRun);
+
+  process.stdout.write(`Configured inner repo using ${variantPath}\n`);
+  process.stdout.write(`- widgetId: ${widgetId}\n`);
+  process.stdout.write(`- appName: ${appName}\n`);
+  process.stdout.write(`- version: ${version}\n`);
+  process.stdout.write(`- releaseEndpoint: ${endpoints.releaseEndpoint}\n`);
+  process.stdout.write(`- audioEndpoint: ${endpoints.audioEndpoint}\n`);
+}
+
+main();


### PR DESCRIPTION
Add a script and update build configuration to enable variant-driven builds for multiple app store listings.

This allows an "outer repo" to configure the "inner repo" (this codebase) with specific app identifiers, names, and API endpoints, facilitating the creation of distinct app flavors from a single source for different App Store/Play Store listings.

---
<a href="https://cursor.com/background-agent?bcId=bc-41cdcc34-1f03-4b52-875c-71a2199c0c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41cdcc34-1f03-4b52-875c-71a2199c0c05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

